### PR TITLE
Housing affordability website widget

### DIFF
--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/StaticResources/SharedResources/BaseThemes/CY24SU08.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/StaticResources/SharedResources/BaseThemes/CY24SU08.json
@@ -1,0 +1,723 @@
+{
+  "name": "CY24SU08",
+  "dataColors": [
+    "#118DFF",
+    "#12239E",
+    "#E66C37",
+    "#6B007B",
+    "#E044A7",
+    "#744EC2",
+    "#D9B300",
+    "#D64550",
+    "#197278",
+    "#1AAB40",
+    "#15C6F4",
+    "#4092FF",
+    "#FFA058",
+    "#BE5DC9",
+    "#F472D0",
+    "#B5A1FF",
+    "#C4A200",
+    "#FF8080",
+    "#00DBBC",
+    "#5BD667",
+    "#0091D5",
+    "#4668C5",
+    "#FF6300",
+    "#99008A",
+    "#EC008C",
+    "#533285",
+    "#99700A",
+    "#FF4141",
+    "#1F9A85",
+    "#25891C",
+    "#0057A2",
+    "#002050",
+    "#C94F0F",
+    "#450F54",
+    "#B60064",
+    "#34124F",
+    "#6A5A29",
+    "#1AAB40",
+    "#BA141A",
+    "#0C3D37",
+    "#0B511F"
+  ],
+  "foreground": "#252423",
+  "foregroundNeutralSecondary": "#605E5C",
+  "foregroundNeutralTertiary": "#B3B0AD",
+  "background": "#FFFFFF",
+  "backgroundLight": "#F3F2F1",
+  "backgroundNeutral": "#C8C6C4",
+  "tableAccent": "#118DFF",
+  "good": "#1AAB40",
+  "neutral": "#D9B300",
+  "bad": "#D64554",
+  "maximum": "#118DFF",
+  "center": "#D9B300",
+  "minimum": "#DEEFFF",
+  "null": "#FF7F48",
+  "hyperlink": "#0078d4",
+  "visitedHyperlink": "#0078d4",
+  "textClasses": {
+    "callout": {
+      "fontSize": 45,
+      "fontFace": "DIN",
+      "color": "#252423"
+    },
+    "title": {
+      "fontSize": 12,
+      "fontFace": "DIN",
+      "color": "#252423"
+    },
+    "header": {
+      "fontSize": 12,
+      "fontFace": "Segoe UI Semibold",
+      "color": "#252423"
+    },
+    "label": {
+      "fontSize": 10,
+      "fontFace": "Segoe UI",
+      "color": "#252423"
+    }
+  },
+  "visualStyles": {
+    "*": {
+      "*": {
+        "*": [
+          {
+            "wordWrap": true
+          }
+        ],
+        "line": [
+          {
+            "transparency": 0
+          }
+        ],
+        "outline": [
+          {
+            "transparency": 0
+          }
+        ],
+        "plotArea": [
+          {
+            "transparency": 0
+          }
+        ],
+        "categoryAxis": [
+          {
+            "showAxisTitle": true,
+            "gridlineStyle": "dotted",
+            "concatenateLabels": false
+          }
+        ],
+        "valueAxis": [
+          {
+            "showAxisTitle": true,
+            "gridlineStyle": "dotted"
+          }
+        ],
+        "y2Axis": [
+          {
+            "show": true
+          }
+        ],
+        "title": [
+          {
+            "titleWrap": true
+          }
+        ],
+        "lineStyles": [
+          {
+            "strokeWidth": 3
+          }
+        ],
+        "wordWrap": [
+          {
+            "show": true
+          }
+        ],
+        "background": [
+          {
+            "show": true,
+            "transparency": 0
+          }
+        ],
+        "border": [
+          {
+            "width": 1
+          }
+        ],
+        "outspacePane": [
+          {
+            "backgroundColor": {
+              "solid": {
+                "color": "#ffffff"
+              }
+            },
+            "transparency": 0,
+            "border": true,
+            "borderColor": {
+              "solid": {
+                "color": "#B3B0AD"
+              }
+            }
+          }
+        ],
+        "filterCard": [
+          {
+            "$id": "Applied",
+            "transparency": 0,
+            "foregroundColor": {
+              "solid": {
+                "color": "#252423"
+              }
+            },
+            "border": true
+          },
+          {
+            "$id": "Available",
+            "transparency": 0,
+            "foregroundColor": {
+              "solid": {
+                "color": "#252423"
+              }
+            },
+            "border": true
+          }
+        ]
+      }
+    },
+    "scatterChart": {
+      "*": {
+        "bubbles": [
+          {
+            "bubbleSize": -10,
+            "markerRangeType": "auto"
+          }
+        ],
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "fillPoint": [
+          {
+            "show": true
+          }
+        ],
+        "legend": [
+          {
+            "showGradientLegend": true
+          }
+        ]
+      }
+    },
+    "lineChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ],
+        "forecast": [
+          {
+            "matchSeriesInterpolation": true
+          }
+        ]
+      }
+    },
+    "map": {
+      "*": {
+        "bubbles": [
+          {
+            "bubbleSize": -10,
+            "markerRangeType": "auto"
+          }
+        ]
+      }
+    },
+    "azureMap": {
+      "*": {
+        "bubbleLayer": [
+          {
+            "bubbleRadius": 8,
+            "minBubbleRadius": 8,
+            "maxRadius": 40
+          }
+        ],
+        "barChart": [
+          {
+            "barHeight": 3,
+            "thickness": 3
+          }
+        ]
+      }
+    },
+    "pieChart": {
+      "*": {
+        "legend": [
+          {
+            "show": true,
+            "position": "RightCenter"
+          }
+        ],
+        "labels": [
+          {
+            "labelStyle": "Data value, percent of total"
+          }
+        ]
+      }
+    },
+    "donutChart": {
+      "*": {
+        "legend": [
+          {
+            "show": true,
+            "position": "RightCenter"
+          }
+        ],
+        "labels": [
+          {
+            "labelStyle": "Data value, percent of total"
+          }
+        ]
+      }
+    },
+    "pivotTable": {
+      "*": {
+        "rowHeaders": [
+          {
+            "showExpandCollapseButtons": true,
+            "legacyStyleDisabled": true
+          }
+        ]
+      }
+    },
+    "multiRowCard": {
+      "*": {
+        "card": [
+          {
+            "outlineWeight": 2,
+            "barShow": true,
+            "barWeight": 2
+          }
+        ]
+      }
+    },
+    "kpi": {
+      "*": {
+        "trendline": [
+          {
+            "transparency": 20
+          }
+        ]
+      }
+    },
+    "cardVisual": {
+      "*": {
+        "layout": [
+          {
+            "maxTiles": 3
+          }
+        ],
+        "overflow": [
+          {
+            "type": 0
+          }
+        ],
+        "image": [
+          {
+            "fixedSize": false
+          },
+          {
+            "imageAreaSize": 50
+          }
+        ]
+      }
+    },
+    "advancedSlicerVisual": {
+      "*": {
+        "layout": [
+          {
+            "maxTiles": 3
+          }
+        ]
+      }
+    },
+    "slicer": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "date": [
+          {
+            "hideDatePickerButton": false
+          }
+        ],
+        "items": [
+          {
+            "padding": 4,
+            "accessibilityContrastProperties": true
+          }
+        ]
+      }
+    },
+    "waterfallChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ]
+      }
+    },
+    "columnChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "legend": [
+          {
+            "showGradientLegend": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "clusteredColumnChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "legend": [
+          {
+            "showGradientLegend": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "hundredPercentStackedColumnChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "legend": [
+          {
+            "showGradientLegend": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "barChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "legend": [
+          {
+            "showGradientLegend": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "clusteredBarChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "legend": [
+          {
+            "showGradientLegend": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "hundredPercentStackedBarChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "legend": [
+          {
+            "showGradientLegend": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "areaChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "stackedAreaChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "lineClusteredColumnComboChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "lineStackedColumnComboChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "smallMultiplesLayout": [
+          {
+            "backgroundTransparency": 0,
+            "gridLineType": "inner"
+          }
+        ]
+      }
+    },
+    "ribbonChart": {
+      "*": {
+        "general": [
+          {
+            "responsive": true
+          }
+        ],
+        "valueAxis": [
+          {
+            "show": true
+          }
+        ]
+      }
+    },
+    "group": {
+      "*": {
+        "background": [
+          {
+            "show": false
+          }
+        ]
+      }
+    },
+    "basicShape": {
+      "*": {
+        "background": [
+          {
+            "show": false
+          }
+        ],
+        "general": [
+          {
+            "keepLayerOrder": true
+          }
+        ],
+        "visualHeader": [
+          {
+            "show": false
+          }
+        ]
+      }
+    },
+    "shape": {
+      "*": {
+        "background": [
+          {
+            "show": false
+          }
+        ],
+        "general": [
+          {
+            "keepLayerOrder": true
+          }
+        ],
+        "visualHeader": [
+          {
+            "show": false
+          }
+        ]
+      }
+    },
+    "image": {
+      "*": {
+        "background": [
+          {
+            "show": false
+          }
+        ],
+        "general": [
+          {
+            "keepLayerOrder": true
+          }
+        ],
+        "visualHeader": [
+          {
+            "show": false
+          }
+        ],
+        "lockAspect": [
+          {
+            "show": true
+          }
+        ]
+      }
+    },
+    "actionButton": {
+      "*": {
+        "background": [
+          {
+            "show": false
+          }
+        ],
+        "visualHeader": [
+          {
+            "show": false
+          }
+        ]
+      }
+    },
+    "pageNavigator": {
+      "*": {
+        "background": [
+          {
+            "show": false
+          }
+        ],
+        "visualHeader": [
+          {
+            "show": false
+          }
+        ]
+      }
+    },
+    "bookmarkNavigator": {
+      "*": {
+        "background": [
+          {
+            "show": false
+          }
+        ],
+        "visualHeader": [
+          {
+            "show": false
+          }
+        ]
+      }
+    },
+    "textbox": {
+      "*": {
+        "general": [
+          {
+            "keepLayerOrder": true
+          }
+        ],
+        "visualHeader": [
+          {
+            "show": false
+          }
+        ]
+      }
+    },
+    "page": {
+      "*": {
+        "outspace": [
+          {
+            "color": {
+              "solid": {
+                "color": "#FFFFFF"
+              }
+            }
+          }
+        ],
+        "background": [
+          {
+            "transparency": 100
+          }
+        ]
+      }
+    }
+  }
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition.pbir
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition.pbir
@@ -1,0 +1,9 @@
+{
+  "version": "4.0",
+  "datasetReference": {
+    "byPath": {
+      "path": "../DataKit_Housing_Affordability.SemanticModel"
+    },
+    "byConnection": null
+  }
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/6541a9ecfd461cd5caa5/page.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/6541a9ecfd461cd5caa5/page.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.2.0/schema.json",
+  "name": "6541a9ecfd461cd5caa5",
+  "displayName": "Graphical view",
+  "displayOption": "FitToPage",
+  "height": 720,
+  "width": 1280
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/6541a9ecfd461cd5caa5/visuals/07ec148083a0f538653c/visual.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/6541a9ecfd461cd5caa5/visuals/07ec148083a0f538653c/visual.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/1.2.0/schema.json",
+  "name": "07ec148083a0f538653c",
+  "position": {
+    "x": 137.14285714285714,
+    "y": 438.57142857142861,
+    "z": 2000,
+    "height": 281.42857142857144,
+    "width": 432.85714285714289,
+    "tabOrder": 2000
+  },
+  "visual": {
+    "visualType": "barChart",
+    "query": {
+      "queryState": {
+        "Category": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Renter households, cost burden by income"
+                    }
+                  },
+                  "Property": "Household Income"
+                }
+              },
+              "queryRef": "Renter households, cost burden by income.Household Income",
+              "nativeQueryRef": "Household Income",
+              "active": true
+            }
+          ]
+        },
+        "Y": {
+          "projections": [
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Renter households, cost burden by income"
+                        }
+                      },
+                      "Property": "30% or less"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Renter households, cost burden by income.30% or less)",
+              "nativeQueryRef": "30% or less",
+              "displayName": "30% or less"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Renter households, cost burden by income"
+                        }
+                      },
+                      "Property": "30.1-50%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Renter households, cost burden by income.30.1-50%)",
+              "nativeQueryRef": "30.1-50%",
+              "displayName": "30.1-50%"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Renter households, cost burden by income"
+                        }
+                      },
+                      "Property": "More than 50%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Renter households, cost burden by income.More than 50%)",
+              "nativeQueryRef": "More than 50%",
+              "displayName": "More than 50%"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "Renter households, cost burden by income"
+                  }
+                },
+                "Property": "Household Income"
+              }
+            },
+            "direction": "Descending"
+          }
+        ]
+      }
+    },
+    "objects": {
+      "valueAxis": [
+        {
+          "properties": {
+            "titleText": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Households'"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "title": [
+        {
+          "properties": {
+            "text": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Renters'"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/6541a9ecfd461cd5caa5/visuals/55e81f184e390aab84f1/visual.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/6541a9ecfd461cd5caa5/visuals/55e81f184e390aab84f1/visual.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/1.2.0/schema.json",
+  "name": "55e81f184e390aab84f1",
+  "position": {
+    "x": 661.42857142857144,
+    "y": 438.57142857142861,
+    "z": 3000,
+    "height": 281.42857142857144,
+    "width": 448.57142857142861,
+    "tabOrder": 3000
+  },
+  "visual": {
+    "visualType": "barChart",
+    "query": {
+      "queryState": {
+        "Category": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Owner-occupied households, cost burden by income"
+                    }
+                  },
+                  "Property": "Household Income"
+                }
+              },
+              "queryRef": "Owner-occupied households, cost burden by income.Household Income",
+              "nativeQueryRef": "Household Income",
+              "active": true
+            }
+          ]
+        },
+        "Y": {
+          "projections": [
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Owner-occupied households, cost burden by income"
+                        }
+                      },
+                      "Property": "30% or less"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Owner-occupied households, cost burden by income.30% or less)",
+              "nativeQueryRef": "30% or less",
+              "displayName": "30% or less"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Owner-occupied households, cost burden by income"
+                        }
+                      },
+                      "Property": "30.1-50%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Owner-occupied households, cost burden by income.30.1-50%)",
+              "nativeQueryRef": "30.1-50%",
+              "displayName": "30.1-50%"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Owner-occupied households, cost burden by income"
+                        }
+                      },
+                      "Property": "More than 50%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Owner-occupied households, cost burden by income.More than 50%)",
+              "nativeQueryRef": "More than 50%",
+              "displayName": "More than 50%"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "Owner-occupied households, cost burden by income"
+                  }
+                },
+                "Property": "Household Income"
+              }
+            },
+            "direction": "Descending"
+          }
+        ]
+      }
+    },
+    "objects": {
+      "valueAxis": [
+        {
+          "properties": {
+            "titleText": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Households'"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "title": [
+        {
+          "properties": {
+            "text": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Owners'"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/6541a9ecfd461cd5caa5/visuals/8e72f35ed9c79055c70a/visual.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/6541a9ecfd461cd5caa5/visuals/8e72f35ed9c79055c70a/visual.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/1.2.0/schema.json",
+  "name": "8e72f35ed9c79055c70a",
+  "position": {
+    "x": 354.28571428571428,
+    "y": 78.571428571428569,
+    "z": 1000,
+    "height": 318.57142857142861,
+    "width": 571.42857142857144,
+    "tabOrder": 1000
+  },
+  "visual": {
+    "visualType": "barChart",
+    "query": {
+      "queryState": {
+        "Category": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "All households, cost burden by income"
+                    }
+                  },
+                  "Property": "Household Income"
+                }
+              },
+              "queryRef": "All households, cost burden by income.Household Income",
+              "nativeQueryRef": "Household Income",
+              "active": true
+            }
+          ]
+        },
+        "Y": {
+          "projections": [
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "All households, cost burden by income"
+                        }
+                      },
+                      "Property": "30% or less"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(All households, cost burden by income.30% or less)",
+              "nativeQueryRef": "30% or less",
+              "displayName": "30% or less"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "All households, cost burden by income"
+                        }
+                      },
+                      "Property": "30.1-50%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(All households, cost burden by income.30.1-50%)",
+              "nativeQueryRef": "30.1-50%",
+              "displayName": "30.1-50%"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "All households, cost burden by income"
+                        }
+                      },
+                      "Property": "More than 50%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(All households, cost burden by income.More than 50%)",
+              "nativeQueryRef": "More than 50%",
+              "displayName": "More than 50%"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "All households, cost burden by income"
+                  }
+                },
+                "Property": "Household Income"
+              }
+            },
+            "direction": "Descending"
+          }
+        ]
+      }
+    },
+    "objects": {
+      "layout": [
+        {
+          "properties": {
+            "seriesOrderSorted": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "valueAxis": [
+        {
+          "properties": {
+            "titleText": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Households'"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "title": [
+        {
+          "properties": {
+            "text": {
+              "expr": {
+                "Literal": {
+                  "Value": "'All households'"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/6541a9ecfd461cd5caa5/visuals/9a65fc2a9f74eefbdd04/visual.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/6541a9ecfd461cd5caa5/visuals/9a65fc2a9f74eefbdd04/visual.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/1.2.0/schema.json",
+  "name": "9a65fc2a9f74eefbdd04",
+  "position": {
+    "x": 211.42857142857144,
+    "y": 8.5714285714285712,
+    "z": 4000,
+    "height": 60.000000000000007,
+    "width": 855.71428571428578,
+    "tabOrder": 4000
+  },
+  "visual": {
+    "visualType": "textbox",
+    "objects": {
+      "general": [
+        {
+          "properties": {
+            "paragraphs": [
+              {
+                "textRuns": [
+                  {
+                    "value": "Proportion of income dedicate to housing, per income level",
+                    "textStyle": {
+                      "fontSize": "24pt"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/6541a9ecfd461cd5caa5/visuals/d66e07256b80c1598291/visual.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/6541a9ecfd461cd5caa5/visuals/d66e07256b80c1598291/visual.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/1.2.0/schema.json",
+  "name": "d66e07256b80c1598291",
+  "position": {
+    "x": 0,
+    "y": 68.571428571428569,
+    "z": 0,
+    "height": 78.571428571428569,
+    "width": 221.42857142857144,
+    "tabOrder": 0
+  },
+  "visual": {
+    "visualType": "slicer",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Medium income by tenure"
+                    }
+                  },
+                  "Property": "Geography Key"
+                }
+              },
+              "queryRef": "Medium income by tenure.Geography Key",
+              "nativeQueryRef": "Geography Key",
+              "active": true
+            }
+          ]
+        }
+      }
+    },
+    "objects": {
+      "data": [
+        {
+          "properties": {
+            "mode": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Dropdown'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "selection": [
+        {
+          "properties": {
+            "strictSingleSelect": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "general": [
+        {
+          "properties": {
+            "filter": {
+              "filter": {
+                "Version": 2,
+                "From": [
+                  {
+                    "Name": "m",
+                    "Entity": "Medium income by tenure",
+                    "Type": 0
+                  }
+                ],
+                "Where": [
+                  {
+                    "Condition": {
+                      "In": {
+                        "Expressions": [
+                          {
+                            "Column": {
+                              "Expression": {
+                                "SourceRef": {
+                                  "Source": "m"
+                                }
+                              },
+                              "Property": "Geography Key"
+                            }
+                          }
+                        ],
+                        "Values": [
+                          [
+                            {
+                              "Literal": {
+                                "Value": "'Alachua'"
+                              }
+                            }
+                          ]
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "syncGroup": {
+      "groupName": "Geography Key",
+      "fieldChanges": true,
+      "filterChanges": true
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/page.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/page.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.2.0/schema.json",
+  "name": "cd7c7f0244b5fc2d5f06",
+  "displayName": "Table View",
+  "displayOption": "FitToPage",
+  "height": 720,
+  "width": 1280
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/visuals/00caa2c80a2a8ef5f624/visual.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/visuals/00caa2c80a2a8ef5f624/visual.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/1.2.0/schema.json",
+  "name": "00caa2c80a2a8ef5f624",
+  "position": {
+    "x": 18.584392014519057,
+    "y": 121.9600725952813,
+    "z": 3000,
+    "height": 205.58983666061707,
+    "width": 889.72776769509983,
+    "tabOrder": 0
+  },
+  "visual": {
+    "visualType": "tableEx",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "All households, cost burden by income"
+                    }
+                  },
+                  "Property": "Household Income"
+                }
+              },
+              "queryRef": "All households, cost burden by income.Household Income",
+              "nativeQueryRef": "Household Income"
+            },
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "All households, cost burden by income"
+                    }
+                  },
+                  "Property": "Upper Limit (All)"
+                }
+              },
+              "queryRef": "All households, cost burden by income.All Upper Limit",
+              "nativeQueryRef": "Upper Limit (All)"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "All households, cost burden by income"
+                        }
+                      },
+                      "Property": "30% or less"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(All households, cost burden by income.30% or less)",
+              "nativeQueryRef": "Sum of 30% or less"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "All households, cost burden by income"
+                        }
+                      },
+                      "Property": "30.1-50%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(All households, cost burden by income.30.1-50%)",
+              "nativeQueryRef": "Sum of 30.1-50%"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "All households, cost burden by income"
+                        }
+                      },
+                      "Property": "More than 50%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(All households, cost burden by income.More than 50%)",
+              "nativeQueryRef": "Sum of More than 50%"
+            },
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "All households, cost burden by income"
+                    }
+                  },
+                  "Property": "Total households"
+                }
+              },
+              "queryRef": "All households, cost burden by income.Total",
+              "nativeQueryRef": "Total households"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "All households, cost burden by income"
+                        }
+                      },
+                      "Property": "Above 30%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(All households, cost burden by income.Above 30%)",
+              "nativeQueryRef": "Sum of Above 30%"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "All households, cost burden by income"
+                  }
+                },
+                "Property": "Household Income"
+              }
+            },
+            "direction": "Ascending"
+          }
+        ]
+      }
+    },
+    "objects": {
+      "total": [
+        {
+          "properties": {
+            "totals": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "visualContainerObjects": {
+      "title": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "text": {
+              "expr": {
+                "Literal": {
+                  "Value": "'All households'"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/visuals/1749a46a025d2ddefc6f/visual.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/visuals/1749a46a025d2ddefc6f/visual.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/1.2.0/schema.json",
+  "name": "1749a46a025d2ddefc6f",
+  "position": {
+    "x": 18.584392014519057,
+    "y": 29.038112522686024,
+    "z": 4000,
+    "height": 92.921960072595283,
+    "width": 315.93466424682396,
+    "tabOrder": 1000
+  },
+  "visual": {
+    "visualType": "slicer",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Medium income by tenure"
+                    }
+                  },
+                  "Property": "Geography Key"
+                }
+              },
+              "queryRef": "Medium income by tenure.Geography Key",
+              "nativeQueryRef": "Geography Key",
+              "active": true
+            }
+          ]
+        }
+      }
+    },
+    "objects": {
+      "data": [
+        {
+          "properties": {
+            "mode": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Dropdown'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "selection": [
+        {
+          "properties": {
+            "strictSingleSelect": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "general": [
+        {
+          "properties": {
+            "filter": {
+              "filter": {
+                "Version": 2,
+                "From": [
+                  {
+                    "Name": "m",
+                    "Entity": "Medium income by tenure",
+                    "Type": 0
+                  }
+                ],
+                "Where": [
+                  {
+                    "Condition": {
+                      "In": {
+                        "Expressions": [
+                          {
+                            "Column": {
+                              "Expression": {
+                                "SourceRef": {
+                                  "Source": "m"
+                                }
+                              },
+                              "Property": "Geography Key"
+                            }
+                          }
+                        ],
+                        "Values": [
+                          [
+                            {
+                              "Literal": {
+                                "Value": "'Alachua'"
+                              }
+                            }
+                          ]
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "syncGroup": {
+      "groupName": "Geography Key",
+      "fieldChanges": true,
+      "filterChanges": true
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/visuals/3e3fa15c82b2e3e61171/visual.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/visuals/3e3fa15c82b2e3e61171/visual.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/1.2.0/schema.json",
+  "name": "3e3fa15c82b2e3e61171",
+  "position": {
+    "x": 757.14285714285722,
+    "y": 551.42857142857144,
+    "z": 0,
+    "height": 152.14285714285714,
+    "width": 346.42857142857144,
+    "tabOrder": 6000
+  },
+  "visual": {
+    "visualType": "tableEx",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Owner-occupied households, cost burden by income"
+                    }
+                  },
+                  "Property": "Household Income"
+                }
+              },
+              "queryRef": "Owner-occupied households, cost burden by income.Household Income",
+              "nativeQueryRef": "Household Income"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Owner-occupied households, cost burden by income"
+                        }
+                      },
+                      "Property": "Percent Above 30%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Owner-occupied households, cost burden by income.Percent Above 30%)",
+              "nativeQueryRef": "Percent Above 30%",
+              "displayName": "Percent Above 30%"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "Owner-occupied households, cost burden by income"
+                  }
+                },
+                "Property": "Household Income"
+              }
+            },
+            "direction": "Ascending"
+          }
+        ]
+      }
+    },
+    "objects": {
+      "total": [
+        {
+          "properties": {
+            "totals": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/visuals/a421e6787cfe2d3c58e7/visual.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/visuals/a421e6787cfe2d3c58e7/visual.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/1.2.0/schema.json",
+  "name": "a421e6787cfe2d3c58e7",
+  "position": {
+    "x": 759.28571428571433,
+    "y": 140.71428571428572,
+    "z": 2000,
+    "height": 205.71428571428572,
+    "width": 335.71428571428572,
+    "tabOrder": 4000
+  },
+  "visual": {
+    "visualType": "tableEx",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "All households, cost burden by income"
+                    }
+                  },
+                  "Property": "Household Income"
+                }
+              },
+              "queryRef": "All households, cost burden by income.Household Income",
+              "nativeQueryRef": "Household Income"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "All households, cost burden by income"
+                        }
+                      },
+                      "Property": "Percent above 30%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(All households, cost burden by income.Percent above 30%)",
+              "nativeQueryRef": "Percent above 30%",
+              "displayName": "Percent above 30%"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Aggregation": {
+                "Expression": {
+                  "Column": {
+                    "Expression": {
+                      "SourceRef": {
+                        "Entity": "All households, cost burden by income"
+                      }
+                    },
+                    "Property": "Percent above 30%"
+                  }
+                },
+                "Function": 0
+              }
+            },
+            "direction": "Descending"
+          }
+        ]
+      }
+    },
+    "objects": {
+      "total": [
+        {
+          "properties": {
+            "totals": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "columnFormatting": [
+        {
+          "properties": {
+            "styleValues": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "styleTotal": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          },
+          "selector": {
+            "metadata": "All households, cost burden by income.Household Income"
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/visuals/be186090f396f9d056ef/visual.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/visuals/be186090f396f9d056ef/visual.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/1.2.0/schema.json",
+  "name": "be186090f396f9d056ef",
+  "position": {
+    "x": 756.15384615384608,
+    "y": 344.61538461538458,
+    "z": 1000,
+    "height": 184.61538461538461,
+    "width": 337.69230769230768,
+    "tabOrder": 5000
+  },
+  "visual": {
+    "visualType": "tableEx",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Renter households, cost burden by income"
+                    }
+                  },
+                  "Property": "Household Income"
+                }
+              },
+              "queryRef": "Renter households, cost burden by income.Household Income",
+              "nativeQueryRef": "Household Income"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Renter households, cost burden by income"
+                        }
+                      },
+                      "Property": "Percent Above 30%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Renter households, cost burden by income.Percent Above 30%)",
+              "nativeQueryRef": "Percent Above 30%",
+              "displayName": "Percent Above 30%"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "Renter households, cost burden by income"
+                  }
+                },
+                "Property": "Household Income"
+              }
+            },
+            "direction": "Ascending"
+          }
+        ]
+      }
+    },
+    "objects": {
+      "total": [
+        {
+          "properties": {
+            "totals": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/visuals/f6994bee435beef0cdc5/visual.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/visuals/f6994bee435beef0cdc5/visual.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/1.2.0/schema.json",
+  "name": "f6994bee435beef0cdc5",
+  "position": {
+    "x": 18.584392014519057,
+    "y": 531.978221415608,
+    "z": 6000,
+    "height": 178.87477313974591,
+    "width": 889.72776769509983,
+    "tabOrder": 3000
+  },
+  "visual": {
+    "visualType": "tableEx",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Owner-occupied households, cost burden by income"
+                    }
+                  },
+                  "Property": "Household Income"
+                }
+              },
+              "queryRef": "Owner-occupied households, cost burden by income.Household Income",
+              "nativeQueryRef": "Household Income"
+            },
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Owner-occupied households, cost burden by income"
+                    }
+                  },
+                  "Property": "Upper Limit (Owner)"
+                }
+              },
+              "queryRef": "Owner-occupied households, cost burden by income.Upper Limit (Owner)",
+              "nativeQueryRef": "Upper Limit (Owner)"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Owner-occupied households, cost burden by income"
+                        }
+                      },
+                      "Property": "30% or less"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Owner-occupied households, cost burden by income.30% or less)",
+              "nativeQueryRef": "Sum of 30% or less"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Owner-occupied households, cost burden by income"
+                        }
+                      },
+                      "Property": "30.1-50%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Owner-occupied households, cost burden by income.30.1-50%)",
+              "nativeQueryRef": "Sum of 30.1-50%"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Owner-occupied households, cost burden by income"
+                        }
+                      },
+                      "Property": "More than 50%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Owner-occupied households, cost burden by income.More than 50%)",
+              "nativeQueryRef": "Sum of More than 50%"
+            },
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Owner-occupied households, cost burden by income"
+                    }
+                  },
+                  "Property": "Total owners"
+                }
+              },
+              "queryRef": "Owner-occupied households, cost burden by income.Total owners",
+              "nativeQueryRef": "Total owners"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Owner-occupied households, cost burden by income"
+                        }
+                      },
+                      "Property": "Above 30%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Owner-occupied households, cost burden by income.Above 30%)",
+              "nativeQueryRef": "Sum of Above 30%"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "Owner-occupied households, cost burden by income"
+                  }
+                },
+                "Property": "Household Income"
+              }
+            },
+            "direction": "Ascending"
+          }
+        ]
+      }
+    },
+    "visualContainerObjects": {
+      "title": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "text": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Owners'"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/visuals/fc98e741b83e72a14d56/visual.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/cd7c7f0244b5fc2d5f06/visuals/fc98e741b83e72a14d56/visual.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/1.2.0/schema.json",
+  "name": "fc98e741b83e72a14d56",
+  "position": {
+    "x": 18.584392014519057,
+    "y": 326.38838475499091,
+    "z": 5000,
+    "height": 205.58983666061707,
+    "width": 889.72776769509983,
+    "tabOrder": 2000
+  },
+  "visual": {
+    "visualType": "tableEx",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Renter households, cost burden by income"
+                    }
+                  },
+                  "Property": "Household Income"
+                }
+              },
+              "queryRef": "Renter households, cost burden by income.Household Income",
+              "nativeQueryRef": "Household Income"
+            },
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Renter households, cost burden by income"
+                    }
+                  },
+                  "Property": "Upper Limit (Renter)"
+                }
+              },
+              "queryRef": "Renter households, cost burden by income.Upper Limit (Renter)",
+              "nativeQueryRef": "Upper Limit (Renter)"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Renter households, cost burden by income"
+                        }
+                      },
+                      "Property": "30% or less"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Renter households, cost burden by income.30% or less)",
+              "nativeQueryRef": "Sum of 30% or less"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Renter households, cost burden by income"
+                        }
+                      },
+                      "Property": "30.1-50%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Renter households, cost burden by income.30.1-50%)",
+              "nativeQueryRef": "Sum of 30.1-50%"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Renter households, cost burden by income"
+                        }
+                      },
+                      "Property": "More than 50%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Renter households, cost burden by income.More than 50%)",
+              "nativeQueryRef": "Sum of More than 50%"
+            },
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Renter households, cost burden by income"
+                    }
+                  },
+                  "Property": "Total renters"
+                }
+              },
+              "queryRef": "Renter households, cost burden by income.Total renters",
+              "nativeQueryRef": "Total renters"
+            },
+            {
+              "field": {
+                "Aggregation": {
+                  "Expression": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Entity": "Renter households, cost burden by income"
+                        }
+                      },
+                      "Property": "Above 30%"
+                    }
+                  },
+                  "Function": 0
+                }
+              },
+              "queryRef": "Sum(Renter households, cost burden by income.Above 30%)",
+              "nativeQueryRef": "Sum of Above 30%"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "Renter households, cost burden by income"
+                  }
+                },
+                "Property": "Household Income"
+              }
+            },
+            "direction": "Ascending"
+          }
+        ]
+      }
+    },
+    "visualContainerObjects": {
+      "title": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "text": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Renters'"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/pages.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/pages/pages.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/pagesMetadata/1.0.0/schema.json",
+  "pageOrder": [
+    "cd7c7f0244b5fc2d5f06",
+    "6541a9ecfd461cd5caa5"
+  ],
+  "activePageName": "6541a9ecfd461cd5caa5"
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/report.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/report.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/report/1.2.0/schema.json",
+  "themeCollection": {
+    "baseTheme": {
+      "name": "CY24SU08",
+      "reportVersionAtImport": "5.57",
+      "type": "SharedResources"
+    }
+  },
+  "layoutOptimization": "None",
+  "objects": {
+    "section": [
+      {
+        "properties": {
+          "verticalAlignment": {
+            "expr": {
+              "Literal": {
+                "Value": "'Top'"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "outspacePane": [
+      {
+        "properties": {
+          "expanded": {
+            "expr": {
+              "Literal": {
+                "Value": "true"
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+  "resourcePackages": [
+    {
+      "name": "SharedResources",
+      "type": "SharedResources",
+      "items": [
+        {
+          "name": "CY24SU08",
+          "path": "BaseThemes/CY24SU08.json",
+          "type": "BaseTheme"
+        }
+      ]
+    }
+  ],
+  "settings": {
+    "useStylableVisualContainerHeader": true,
+    "defaultDrillFilterOtherVisuals": true,
+    "allowChangeFilterTypes": true,
+    "useEnhancedTooltips": true,
+    "useDefaultAggregateDisplayName": true
+  }
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/version.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.Report/definition/version.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/versionMetadata/1.0.0/schema.json",
+  "version": "2.0.0"
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition.pbism
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition.pbism
@@ -1,0 +1,4 @@
+{
+  "version": "4.0",
+  "settings": {}
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/cultures/en-US.tmdl
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/cultures/en-US.tmdl
@@ -1,0 +1,9 @@
+cultureInfo en-US
+
+	linguisticMetadata =
+			{
+			  "Version": "1.0.0",
+			  "Language": "en-US"
+			}
+		contentType: json
+

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/database.tmdl
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/database.tmdl
@@ -1,0 +1,3 @@
+database
+	compatibilityLevel: 1550
+

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/model.tmdl
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/model.tmdl
@@ -1,0 +1,24 @@
+model Model
+	culture: en-US
+	defaultPowerBIDataSourceVersion: powerBI_V3
+	sourceQueryCulture: en-US
+	dataAccessOptions
+		legacyRedirects
+		returnErrorValuesAsNull
+
+annotation PBI_QueryOrder = ["All households, cost burden by income","Renter households, cost burden by income","Owner-occupied households, cost burden by income","Medium income by tenure"]
+
+annotation __PBI_TimeIntelligenceEnabled = 1
+
+annotation PBIDesktopVersion = 2.136.1202.0 (24.09)
+
+annotation PBI_ProTooling = ["DevMode"]
+
+ref table 'All households, cost burden by income'
+ref table DateTableTemplate_659e404c-5aed-43db-bef9-319f98dee895
+ref table 'Renter households, cost burden by income'
+ref table 'Owner-occupied households, cost burden by income'
+ref table 'Medium income by tenure'
+
+ref cultureInfo en-US
+

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/relationships.tmdl
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/relationships.tmdl
@@ -1,0 +1,12 @@
+relationship 12b3c983-0e9c-511f-2f27-7ef392be44b5
+	fromColumn: 'All households, cost burden by income'.Geography
+	toColumn: 'Medium income by tenure'.'Geography Key'
+
+relationship d5d67461-9cff-4a54-c36f-f9492796ed4d
+	fromColumn: 'Renter households, cost burden by income'.Geography
+	toColumn: 'Medium income by tenure'.'Geography Key'
+
+relationship fc419a70-3809-b825-fd7a-6a2ad56be883
+	fromColumn: 'Owner-occupied households, cost burden by income'.Geography
+	toColumn: 'Medium income by tenure'.'Geography Key'
+

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/tables/All households, cost burden by income.tmdl
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/tables/All households, cost burden by income.tmdl
@@ -1,0 +1,102 @@
+table 'All households, cost burden by income'
+	lineageTag: fa02bb75-4abe-4ec2-a2dc-78dd634ced02
+
+	measure 'Upper Limit (All)' = ```
+			
+			SWITCH(
+			    TRUE(),
+			    MAX('All households, cost burden by income'[Household Income]) = "30% AMI or less", 0.3 * MAX('Medium income by tenure'[All Households]),
+			    MAX('All households, cost burden by income'[Household Income]) = "30.01-50% AMI", 0.5 * MAX('Medium income by tenure'[All Households]),
+			    MAX('All households, cost burden by income'[Household Income]) = "50.01-80% AMI", 0.8 * MAX('Medium income by tenure'[All Households]),
+			    MAX('All households, cost burden by income'[Household Income]) = "80.01-100% AMI", 1 * MAX('Medium income by tenure'[All Households]),
+			    MAX('All households, cost burden by income'[Household Income]) = "Greater than 100% AMI", BLANK()
+			)
+			
+			```
+		formatString: \$#,0;(\$#,0);\$#,0
+		lineageTag: 4ac05519-81fd-43ef-ad1d-6ec9ef0e55ab
+
+	measure 'Total households' = SUM('All households, cost burden by income'[30% or less]) + SUM('All households, cost burden by income'[30.1-50%]) + SUM('All households, cost burden by income'[More than 50%])
+		formatString: #,0
+		lineageTag: bd61f985-7983-4999-b5c9-65f7c3bb4b5f
+
+	column Geography
+		dataType: string
+		lineageTag: 2a4cdd1d-2abd-4f5f-984e-242a3f723345
+		summarizeBy: none
+		sourceColumn: Geography
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'Household Income'
+		dataType: string
+		lineageTag: e0ce1cea-c57e-4386-9ba6-adcf808632c2
+		summarizeBy: none
+		sourceColumn: Household Income
+
+		annotation SummarizationSetBy = User
+
+	column '30% or less'
+		dataType: int64
+		formatString: #,0
+		lineageTag: 985902f9-0fec-46db-a696-2b115c8251e6
+		summarizeBy: sum
+		sourceColumn: 30% or less
+
+		annotation SummarizationSetBy = User
+
+	column '30.1-50%'
+		dataType: int64
+		formatString: #,0
+		lineageTag: b82a2c75-b330-41b7-a11b-b1f0438b47d3
+		summarizeBy: sum
+		sourceColumn: 30.1-50%
+
+		annotation SummarizationSetBy = User
+
+	column 'More than 50%'
+		dataType: int64
+		formatString: #,0
+		lineageTag: c2441434-ee54-4073-9038-3e45f65fc323
+		summarizeBy: sum
+		sourceColumn: More than 50%
+
+		annotation SummarizationSetBy = User
+
+	column 'Above 30%' = 'All households, cost burden by income'[30.1-50%] + 'All households, cost burden by income'[More than 50%]
+		dataType: int64
+		formatString: #,0
+		lineageTag: 762a94b6-5ae7-4326-a9f2-6f5b9396df5a
+		summarizeBy: sum
+		isDataTypeInferred
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'Percent above 30%' = [Above 30%]/([Above 30%] + [30% or less])
+		dataType: double
+		formatString: 0.00%;-0.00%;0.00%
+		lineageTag: 67cbc2be-e565-413b-9e67-3469a4e3a96a
+		summarizeBy: sum
+		isDataTypeInferred
+
+		annotation SummarizationSetBy = Automatic
+
+	partition 'All households, cost burden by income' = m
+		mode: import
+		source =
+				let
+				    Source = Excel.Workbook(File.Contents("C:\Users\Jonathan\Documents\dataKind\DataKit Housing\affordability-2024_09_24-12_09.xlsx"), null, true),
+				    #"Sheet 1_Sheet" = Source{[Item="Sheet 1",Kind="Sheet"]}[Data],
+				    #"Promoted Headers" = Table.PromoteHeaders(#"Sheet 1_Sheet", [PromoteAllScalars=true]),
+				    #"Changed Type" = Table.TransformColumnTypes(#"Promoted Headers",{{"All Households, Cost Burden by Income, 2022 Estimate (Summary)", type text}, {"Column2", type text}, {"Column3", type any}, {"Column4", type any}, {"Column5", type any}}),
+				    #"Renamed Columns" = Table.RenameColumns(#"Changed Type",{{"All Households, Cost Burden by Income, 2022 Estimate (Summary)", "County"}, {"Column2", "Household income"}, {"Column3", "30% or less"}, {"Column4", "30.1-50%"}, {"Column5", "More than 50%"}}),
+				    #"Removed Top Rows" = Table.Skip(#"Renamed Columns",1),
+				    #"Promoted Headers1" = Table.PromoteHeaders(#"Removed Top Rows", [PromoteAllScalars=true]),
+				    #"Changed Type1" = Table.TransformColumnTypes(#"Promoted Headers1",{{"Geography", type text}, {"Household Income", type text}, {"30% or less", Int64.Type}, {"30.1-50%", Int64.Type}, {"More than 50%", Int64.Type}})
+				in
+				    #"Changed Type1"
+
+	annotation PBI_ResultType = Table
+
+	annotation PBI_NavigationStepName = Navigation
+

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/tables/DateTableTemplate_659e404c-5aed-43db-bef9-319f98dee895.tmdl
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/tables/DateTableTemplate_659e404c-5aed-43db-bef9-319f98dee895.tmdl
@@ -1,0 +1,113 @@
+table DateTableTemplate_659e404c-5aed-43db-bef9-319f98dee895
+	isHidden
+	isPrivate
+	lineageTag: c2bf03c8-ffc6-4431-9bcf-8cfb66fce4fd
+
+	column Date
+		dataType: dateTime
+		isHidden
+		lineageTag: 6e88c77b-d632-4c02-ace9-31ac4e6b0e61
+		dataCategory: PaddedDateTableDates
+		summarizeBy: none
+		isNameInferred
+		sourceColumn: [Date]
+
+		annotation SummarizationSetBy = User
+
+	column Year = YEAR([Date])
+		dataType: int64
+		isHidden
+		lineageTag: 18b9e87e-42c8-42b2-9100-1b12cc949682
+		dataCategory: Years
+		summarizeBy: none
+
+		annotation SummarizationSetBy = User
+
+		annotation TemplateId = Year
+
+	column MonthNo = MONTH([Date])
+		dataType: int64
+		isHidden
+		lineageTag: a1672516-1f87-4c29-9091-ed4fbc5c781c
+		dataCategory: MonthOfYear
+		summarizeBy: none
+
+		annotation SummarizationSetBy = User
+
+		annotation TemplateId = MonthNumber
+
+	column Month = FORMAT([Date], "MMMM")
+		dataType: string
+		isHidden
+		lineageTag: 4f92aaa3-9809-41bb-a897-f80b3893a2e9
+		dataCategory: Months
+		summarizeBy: none
+		sortByColumn: MonthNo
+
+		annotation SummarizationSetBy = User
+
+		annotation TemplateId = Month
+
+	column QuarterNo = INT(([MonthNo] + 2) / 3)
+		dataType: int64
+		isHidden
+		lineageTag: 33585b22-1b3a-4745-979b-e42f311ab7f5
+		dataCategory: QuarterOfYear
+		summarizeBy: none
+
+		annotation SummarizationSetBy = User
+
+		annotation TemplateId = QuarterNumber
+
+	column Quarter = "Qtr " & [QuarterNo]
+		dataType: string
+		isHidden
+		lineageTag: 44df8450-70eb-4275-a020-0280f0d9af1c
+		dataCategory: Quarters
+		summarizeBy: none
+		sortByColumn: QuarterNo
+
+		annotation SummarizationSetBy = User
+
+		annotation TemplateId = Quarter
+
+	column Day = DAY([Date])
+		dataType: int64
+		isHidden
+		lineageTag: b0ab1656-0293-41b2-8665-1e95c6b93187
+		dataCategory: DayOfMonth
+		summarizeBy: none
+
+		annotation SummarizationSetBy = User
+
+		annotation TemplateId = Day
+
+	hierarchy 'Date Hierarchy'
+		lineageTag: 4a2ca294-58cd-4589-b2ea-8238c701a75e
+
+		level Year
+			lineageTag: 2fcbeb1e-a3ee-49fd-aa43-0f699f7cfbd2
+			column: Year
+
+		level Quarter
+			lineageTag: 93a646cf-0c0d-4275-b37b-407f55076e98
+			column: Quarter
+
+		level Month
+			lineageTag: 6e2e0f7e-886c-458e-8e41-760740cea547
+			column: Month
+
+		level Day
+			lineageTag: 93affee5-c68f-48b5-acb2-c0d4a89baf68
+			column: Day
+
+		annotation TemplateId = DateHierarchy
+
+	partition DateTableTemplate_659e404c-5aed-43db-bef9-319f98dee895 = calculated
+		mode: import
+		source = Calendar(Date(2015,1,1), Date(2015,1,1))
+
+	annotation __PBI_TemplateDateTable = true
+
+	annotation DefaultItem = DateHierarchy
+

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/tables/Medium income by tenure.tmdl
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/tables/Medium income by tenure.tmdl
@@ -1,0 +1,87 @@
+table 'Medium income by tenure'
+	lineageTag: 021fa4d1-7450-4951-a5f9-b6b46ca93644
+
+	column 'Geography Key'
+		dataType: string
+		lineageTag: 969eea5e-56ef-4e14-b3d8-e3a85ddc3632
+		summarizeBy: none
+		sourceColumn: Geography Key
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'Owner Median Income ($)'
+		dataType: int64
+		formatString: 0
+		lineageTag: 793d4039-5b73-48e6-8a3d-ea0875e5ab87
+		summarizeBy: sum
+		sourceColumn: Owner Median Income ($)
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'Margin of Error (+/-)'
+		dataType: int64
+		formatString: 0
+		lineageTag: 14d0b954-146a-4c62-9169-08d94e3826cd
+		summarizeBy: sum
+		sourceColumn: Margin of Error (+/-)
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'Renter Median Income ($)'
+		dataType: int64
+		formatString: 0
+		lineageTag: fa7a1b7e-8306-4065-a229-e3de1f516253
+		summarizeBy: sum
+		sourceColumn: Renter Median Income ($)
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'Margin of Error (+/-)_1'
+		dataType: int64
+		formatString: 0
+		lineageTag: 2f58344d-7b2d-4c2f-a0ca-1ede71d963d9
+		summarizeBy: sum
+		sourceColumn: Margin of Error (+/-)_1
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'All Households'
+		dataType: int64
+		formatString: #,0
+		lineageTag: 4ef0f8b7-82d0-4967-8bd5-964de9b67e1f
+		summarizeBy: sum
+		sourceColumn: All Households
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'Margin of Error (+/-)_2'
+		dataType: int64
+		formatString: 0
+		lineageTag: 2d507815-29a9-4384-9146-b350ee9e67c8
+		summarizeBy: sum
+		sourceColumn: Margin of Error (+/-)_2
+
+		annotation SummarizationSetBy = Automatic
+
+	partition 'Medium income by tenure' = m
+		mode: import
+		source =
+				let
+				    Source = Excel.Workbook(File.Contents("C:\Users\Jonathan\Documents\dataKind\DataKit Housing\affordability-2024_09_24-12_09.xlsx"), null, true),
+				    #"Sheet 5_Sheet" = Source{[Item="Sheet 5",Kind="Sheet"]}[Data],
+				    #"Promoted Headers" = Table.PromoteHeaders(#"Sheet 5_Sheet", [PromoteAllScalars=true]),
+				    #"Changed Type" = Table.TransformColumnTypes(#"Promoted Headers",{{"Median Income ($) by Tenure, 2018-2022 5-Year Estimates", type text}, {"Column2", type any}, {"Column3", type any}, {"Column4", type any}, {"Column5", type any}, {"Column6", type any}, {"Column7", type any}}),
+				    #"Removed Top Rows" = Table.Skip(#"Changed Type",1),
+				    #"Promoted Headers1" = Table.PromoteHeaders(#"Removed Top Rows", [PromoteAllScalars=true]),
+				    #"Changed Type1" = Table.TransformColumnTypes(#"Promoted Headers1",{{"Geography", type text}, {"Owner Median Income ($)", Int64.Type}, {"Margin of Error (+/-)", Int64.Type}, {"Renter Median Income ($)", Int64.Type}, {"Margin of Error (+/-)_1", Int64.Type}, {"All Households", Int64.Type}, {"Margin of Error (+/-)_2", Int64.Type}}),
+				    #"Added Custom" = Table.AddColumn(#"Changed Type1", "Custom", each Text.BeforeDelimiter([Geography], " ", {0, RelativePosition.FromEnd})),
+				    #"Renamed Columns" = Table.RenameColumns(#"Added Custom",{{"Custom", "Geography Key"}}),
+				    #"Reordered Columns" = Table.ReorderColumns(#"Renamed Columns",{"Geography Key", "Geography", "Owner Median Income ($)", "Margin of Error (+/-)", "Renter Median Income ($)", "Margin of Error (+/-)_1", "All Households", "Margin of Error (+/-)_2"}),
+				    #"Removed Columns" = Table.RemoveColumns(#"Reordered Columns",{"Geography"})
+				in
+				    #"Removed Columns"
+
+	annotation PBI_NavigationStepName = Navigation
+
+	annotation PBI_ResultType = Table
+

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/tables/Owner-occupied households, cost burden by income.tmdl
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/tables/Owner-occupied households, cost burden by income.tmdl
@@ -1,0 +1,101 @@
+table 'Owner-occupied households, cost burden by income'
+	lineageTag: 82d77678-5c4d-4bda-91ca-1370e81d128d
+
+	measure 'Upper Limit (Owner)' =
+			
+			SWITCH(
+			    TRUE(),
+			    MAX('Owner-occupied households, cost burden by income'[Household Income]) =  "30% AMI or less", 0.3 * MAX('Medium income by tenure'[Owner Median Income ($)]),
+			    MAX('Owner-occupied households, cost burden by income'[Household Income]) = "30.01-50% AMI", 0.5 * MAX('Medium income by tenure'[Owner Median Income ($)]),
+			    MAX('Owner-occupied households, cost burden by income'[Household Income]) = "50.01-80% AMI", 0.8 * MAX('Medium income by tenure'[Owner Median Income ($)]),
+			    MAX('Owner-occupied households, cost burden by income'[Household Income]) = "80.01-100% AMI", 1 * MAX('Medium income by tenure'[Owner Median Income ($)]),
+			    MAX('Owner-occupied households, cost burden by income'[Household Income]) = "Greater than 100% AMI", BLANK()
+			)
+		formatString: \$#,0;(\$#,0);\$#,0
+		lineageTag: e73404c9-606a-4fa3-8dc1-10dcfd7f328b
+
+		annotation PBI_FormatHint = {"currencyCulture":"en-US"}
+
+	measure 'Total owners' = SUM('Owner-occupied households, cost burden by income'[30% or less]) + SUM('Owner-occupied households, cost burden by income'[30.1-50%]) + SUM('Owner-occupied households, cost burden by income'[More than 50%])
+		formatString: #,0
+		lineageTag: f4ab78cb-2532-4576-85d9-32d81ca08b82
+
+	column Geography
+		dataType: string
+		lineageTag: 9ccff428-0f35-4ac6-90aa-fab2af97aeb7
+		summarizeBy: none
+		sourceColumn: Geography
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'Household Income'
+		dataType: string
+		lineageTag: 248942ff-07b6-4f34-9de8-fc63ac8ce281
+		summarizeBy: none
+		sourceColumn: Household Income
+
+		annotation SummarizationSetBy = Automatic
+
+	column '30% or less'
+		dataType: int64
+		formatString: #,0
+		lineageTag: f86db7f3-b218-48aa-91fe-20bd3d6edf96
+		summarizeBy: sum
+		sourceColumn: 30% or less
+
+		annotation SummarizationSetBy = Automatic
+
+	column '30.1-50%'
+		dataType: int64
+		formatString: #,0
+		lineageTag: c7d293d7-f1a2-4c3e-aaec-deddd8e02ba1
+		summarizeBy: sum
+		sourceColumn: 30.1-50%
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'More than 50%'
+		dataType: int64
+		formatString: #,0
+		lineageTag: 318c9242-7ad3-43a0-92aa-065ba73793af
+		summarizeBy: sum
+		sourceColumn: More than 50%
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'Above 30%' = 'Owner-occupied households, cost burden by income'[30% or less] + 'Owner-occupied households, cost burden by income'[30.1-50%]
+		dataType: int64
+		formatString: #,0
+		lineageTag: c4588039-ec93-4772-82f9-160793ee3f55
+		summarizeBy: sum
+		isDataTypeInferred
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'Percent Above 30%' = 'Owner-occupied households, cost burden by income'[Above 30%]/'Owner-occupied households, cost burden by income'[Total owners]
+		dataType: double
+		formatString: 0.00%;-0.00%;0.00%
+		lineageTag: 299dcc9a-6999-42e9-9a0a-d6fe900d5b97
+		summarizeBy: sum
+		isDataTypeInferred
+
+		annotation SummarizationSetBy = Automatic
+
+	partition 'Owner-occupied households, cost burden by income' = m
+		mode: import
+		source =
+				let
+				    Source = Excel.Workbook(File.Contents("C:\Users\Jonathan\Documents\dataKind\DataKit Housing\affordability-2024_09_24-12_09.xlsx"), null, true),
+				    #"Sheet 3_Sheet" = Source{[Item="Sheet 3",Kind="Sheet"]}[Data],
+				    #"Promoted Headers" = Table.PromoteHeaders(#"Sheet 3_Sheet", [PromoteAllScalars=true]),
+				    #"Changed Type" = Table.TransformColumnTypes(#"Promoted Headers",{{"Owner-Occupied Households, Cost Burden by Income, 2022 Estimate (Summary)", type text}, {"Column2", type text}, {"Column3", type any}, {"Column4", type any}, {"Column5", type any}}),
+				    #"Removed Top Rows" = Table.Skip(#"Changed Type",1),
+				    #"Promoted Headers1" = Table.PromoteHeaders(#"Removed Top Rows", [PromoteAllScalars=true]),
+				    #"Changed Type1" = Table.TransformColumnTypes(#"Promoted Headers1",{{"Geography", type text}, {"Household Income", type text}, {"30% or less", Int64.Type}, {"30.1-50%", Int64.Type}, {"More than 50%", Int64.Type}})
+				in
+				    #"Changed Type1"
+
+	annotation PBI_ResultType = Table
+
+	annotation PBI_NavigationStepName = Navigation
+

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/tables/Renter households, cost burden by income.tmdl
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/definition/tables/Renter households, cost burden by income.tmdl
@@ -1,0 +1,99 @@
+table 'Renter households, cost burden by income'
+	lineageTag: 44ec7227-bf34-498f-9e8b-c46a6933bdfb
+
+	measure 'Upper Limit (Renter)' =
+			
+			SWITCH(
+			    TRUE(),
+			    MAX('Renter households, cost burden by income'[Household Income]) =  "30% AMI or less", 0.3 * MAX('Medium income by tenure'[Renter Median Income ($)]),
+			    MAX('Renter households, cost burden by income'[Household Income]) = "30.01-50% AMI", 0.5 * MAX('Medium income by tenure'[Renter Median Income ($)]),
+			    MAX('Renter households, cost burden by income'[Household Income]) = "50.01-80% AMI", 0.8 * MAX('Medium income by tenure'[Renter Median Income ($)]),
+			    MAX('Renter households, cost burden by income'[Household Income]) = "80.01-100% AMI", 1 * MAX('Medium income by tenure'[Renter Median Income ($)]),
+			    MAX('Renter households, cost burden by income'[Household Income]) = "Greater than 100% AMI", BLANK()
+			)
+		formatString: \$#,0;(\$#,0);\$#,0
+		lineageTag: 8acf9246-7d7d-4916-a805-b2b2ea5ed12c
+
+	measure 'Total renters' = SUM('Renter households, cost burden by income'[30% or less]) + SUM('Renter households, cost burden by income'[30.1-50%]) + SUM('Renter households, cost burden by income'[More than 50%])
+		formatString: #,0
+		lineageTag: 80b646ea-90bd-419f-9772-b199eb061b60
+
+	column Geography
+		dataType: string
+		lineageTag: d542a0c0-5a76-4ed6-9fa6-5eefd7171a40
+		summarizeBy: none
+		sourceColumn: Geography
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'Household Income'
+		dataType: string
+		lineageTag: ffb5bea2-751e-4f60-ab15-d3719a7bf0f7
+		summarizeBy: none
+		sourceColumn: Household Income
+
+		annotation SummarizationSetBy = Automatic
+
+	column '30% or less'
+		dataType: int64
+		formatString: #,0
+		lineageTag: 1ab97112-d95c-412e-92c2-d886005579f4
+		summarizeBy: sum
+		sourceColumn: 30% or less
+
+		annotation SummarizationSetBy = Automatic
+
+	column '30.1-50%'
+		dataType: int64
+		formatString: #,0
+		lineageTag: a0c213b0-872c-4fc8-bfd2-715bca89ea8a
+		summarizeBy: sum
+		sourceColumn: 30.1-50%
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'More than 50%'
+		dataType: int64
+		formatString: #,0
+		lineageTag: 8adbe25d-73af-472f-8158-e88a1846ff89
+		summarizeBy: sum
+		sourceColumn: More than 50%
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'Above 30%' = [30.1-50%] + [More than 50%]
+		dataType: int64
+		formatString: #,0
+		lineageTag: e8ce4b6e-dbbb-4f9a-8383-c67d196ae5f1
+		summarizeBy: sum
+		isDataTypeInferred
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'Percent Above 30%' = 'Renter households, cost burden by income'[Above 30%]/'Renter households, cost burden by income'[Total renters]
+		dataType: double
+		formatString: 0.00%;-0.00%;0.00%
+		lineageTag: f0715029-01f9-48ab-960b-3fa001e705cb
+		summarizeBy: sum
+		isDataTypeInferred
+
+		annotation SummarizationSetBy = Automatic
+
+	partition 'Renter households, cost burden by income' = m
+		mode: import
+		source =
+				let
+				    Source = Excel.Workbook(File.Contents("C:\Users\Jonathan\Documents\dataKind\DataKit Housing\affordability-2024_09_24-12_09.xlsx"), null, true),
+				    #"Sheet 2_Sheet" = Source{[Item="Sheet 2",Kind="Sheet"]}[Data],
+				    #"Promoted Headers" = Table.PromoteHeaders(#"Sheet 2_Sheet", [PromoteAllScalars=true]),
+				    #"Changed Type" = Table.TransformColumnTypes(#"Promoted Headers",{{"Renter Households, Cost Burden by Income, 2022 Estimate (Summary)", type text}, {"Column2", type text}, {"Column3", type any}, {"Column4", type any}, {"Column5", type any}}),
+				    #"Removed Top Rows" = Table.Skip(#"Changed Type",1),
+				    #"Promoted Headers1" = Table.PromoteHeaders(#"Removed Top Rows", [PromoteAllScalars=true]),
+				    #"Changed Type1" = Table.TransformColumnTypes(#"Promoted Headers1",{{"Geography", type text}, {"Household Income", type text}, {"30% or less", Int64.Type}, {"30.1-50%", Int64.Type}, {"More than 50%", Int64.Type}})
+				in
+				    #"Changed Type1"
+
+	annotation PBI_ResultType = Table
+
+	annotation PBI_NavigationStepName = Navigation
+

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/diagramLayout.json
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.SemanticModel/diagramLayout.json
@@ -1,0 +1,74 @@
+{
+  "version": "1.1.0",
+  "diagrams": [
+    {
+      "ordinal": 0,
+      "scrollPosition": {
+        "x": 0,
+        "y": 0
+      },
+      "nodes": [
+        {
+          "location": {
+            "x": 163.33521126760567,
+            "y": 295.50422535211271
+          },
+          "nodeIndex": "All households, cost burden by income",
+          "nodeLineageTag": "fa02bb75-4abe-4ec2-a2dc-78dd634ced02",
+          "size": {
+            "height": 200,
+            "width": 234
+          },
+          "zIndex": 0
+        },
+        {
+          "location": {
+            "x": 475.45915492957755,
+            "y": 301.99436619718313
+          },
+          "nodeIndex": "Renter households, cost burden by income",
+          "nodeLineageTag": "44ec7227-bf34-498f-9e8b-c46a6933bdfb",
+          "size": {
+            "height": 200,
+            "width": 234
+          },
+          "zIndex": 0
+        },
+        {
+          "location": {
+            "x": 820.03380281690147,
+            "y": 300.91267605633806
+          },
+          "nodeIndex": "Owner-occupied households, cost burden by income",
+          "nodeLineageTag": "82d77678-5c4d-4bda-91ca-1370e81d128d",
+          "size": {
+            "height": 200,
+            "width": 234
+          },
+          "zIndex": 0
+        },
+        {
+          "location": {
+            "x": 528.09014084507021,
+            "y": 0
+          },
+          "nodeIndex": "Medium income by tenure",
+          "nodeLineageTag": "021fa4d1-7450-4951-a5f9-b6b46ca93644",
+          "size": {
+            "height": 248,
+            "width": 234
+          },
+          "zIndex": 0
+        }
+      ],
+      "name": "All tables",
+      "zoomValue": 92.447916666666657,
+      "pinKeyFieldsToTop": false,
+      "showExtraHeaderInfo": false,
+      "hideKeyFieldsWhenCollapsed": false,
+      "tablesLocked": false
+    }
+  ],
+  "selectedDiagram": "All tables",
+  "defaultDiagram": "All tables"
+}

--- a/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.pbip
+++ b/challenge-1/JonathanC's website widget/DataKit_Housing_Affordability.pbip
@@ -1,0 +1,13 @@
+{
+  "version": "1.0",
+  "artifacts": [
+    {
+      "report": {
+        "path": "DataKit_Housing_Affordability.Report"
+      }
+    }
+  ],
+  "settings": {
+    "enableAutoRecovery": true
+  }
+}

--- a/challenge-1/JonathanC's website widget/README.md
+++ b/challenge-1/JonathanC's website widget/README.md
@@ -1,0 +1,4 @@
+This is a PowerBI file meant to be a widget for the client's website
+It represents the different income levels against the proportion of their income dedicated to housing.
+It slices the data acress geography (Florida county) and type of household (Owners vs Rentals).
+This file is built upon the data made available by Shimberg Center for Housing Studies.


### PR DESCRIPTION
This PR is a PowerBI file meant to be published on the client's website

The client had requested a website widget in the video presentation to simplify his Excel analysis pipeline.
This PowerBI file uses the Shimberg Center for Housing Studies dataset and compares household income against proportion of the income dedicate to housing. The data is sliced by area (Florida county) and type of households (Owners vs Renters).